### PR TITLE
remove .toLowerCase so that we can use uppercase when config locales

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,5 +102,5 @@ function registerMethods(helpers, i18n) {
 }
 
 function getLocale(locale) {
-  return (locale || '').toLowerCase();
+  return locale || '';
 }


### PR DESCRIPTION
With current code, we only can setup the locale with lowercase:

```
app.use(i18n(app, {
  directory: './locales',
  //Must keep in lower case because of koa-i18n/index.js:105
  locales: ['zh-cn', 'en-us'],
  header: true
}));
```

Because when we get local name in `koa-i18n/index.js:105`, we directly modify local to lower case...
