### PR TITLE
fix koa-compose to v2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "jade": "*",
     "koa": "1.x",
-    "koa-compose": "*",
+    "koa-compose": "2.x",
     "koa-locale": "*",
     "koa-swig": "2.x",
     "koa-views": "*",


### PR DESCRIPTION
Tests break in v3 (middleware handling has changed) - v3 looks to be for Koa v2.