### PR TITLE
Allow custom locale methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ app.use(i18n(app, {
     'cookie',               //  optional detect cookie      - `Cookie: locale=zh-TW`
     'header',               //  optional detect header      - `Accept-Language: zh-CN,zh;q=0.5`
     'url',                  //  optional detect url         - `/en`
-    'tld'                   //  optional detect tld(the last domain) - `koajs.cn`
+    'tld',                  //  optional detect tld(the last domain) - `koajs.cn`
+    function() {}           //  optional custom function (will be bound to the koa context)
   ]
 }));
 

--- a/index.js
+++ b/index.js
@@ -20,9 +20,11 @@ function I18n(opts) {
   var enables = this.enables = []
   var modes = opts.modes || []
   modes.forEach(function (v) {
-    v = localeMethods.filter(function (t) {
-      return t.toLowerCase() === v.toLowerCase()
-    })[0]
+    if(typeof v !== 'function') {
+      v = localeMethods.filter(function (t) {
+        return t.toLowerCase() === v.toLowerCase()
+      })[0]
+    }
     if (v) {
       enables.push(v)
     }
@@ -89,11 +91,10 @@ function ial(app, opts) {
   });
 
   return function *i18nMiddleware(next) {
-    var i18n = this.i18n
-    var enables = i18n.enables
-    enables.some(function (key) {
-      if (i18n[SET_PREFIX + key]()) return true
-    })
+    this.i18n.enables.some(function (key) {
+      var customLocaleMethod = typeof key === 'function' && this.i18n.setLocale(key.apply(this));
+      if (customLocaleMethod || this.i18n[SET_PREFIX + key]()) return true;
+    }.bind(this));
     yield next
   }
 }


### PR DESCRIPTION
Hi fundon!
We have a use case we would like to fallback to a locale whose value is set by a previous middleware - this PR would allow the user to pass a function as one of their modes (which is executed against the current koa context).
We thought this might be useful to other people too - what do you think?
Thanks!